### PR TITLE
Change req.hostname to req.get('host')

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -232,7 +232,7 @@ router.get('/live', function(req, res, next) {
         layout: 'live',
         subtitle: 'Live',
         query_filter: req.query,
-        request_hostname: req.hostname
+        request_hostname: req.get('host')
     });
 });
 router.get('/problems/domains', function(req, res, next) {
@@ -251,7 +251,7 @@ router.get('/problems/domain/:did', function(req, res, next) {
                 level_list: lvList,
                 domain_id: did,
                 level_progress: lvProgress,
-                request_hostname: req.hostname
+                request_hostname: req.get('host')
             });
         });
     });


### PR DESCRIPTION
在測試時並不是用標準的port(80、443)而發現在live還有部分頁面會出現CORS，後來發現是port不一致所導致的，因為req.hostname只包和網域資訊，不包含port，改為req.get('host')可以解決此問題。